### PR TITLE
Clearly indicate resolved items from debug output

### DIFF
--- a/main.c
+++ b/main.c
@@ -836,7 +836,7 @@ main (int   argc,
       Solvable *s = pool_id2solvable (pool, pile.elements[i]);
       if (g_hash_table_contains (lookaside_repos, s->repo))
         continue;
-      g_print ("%s\n", pool_solvable2str (pool, s));
+      g_print ("INCLUDE: %s\n", pool_solvable2str (pool, s));
     }
 
   return ret;


### PR DESCRIPTION
Both the actual output and debug output end up on stdout, and having this (or any other reasonably unique) prefix here would simplify the job of parsing the output.