### PR TITLE
Always get fresh list of non-default module streams

### DIFF
--- a/main.c
+++ b/main.c
@@ -778,7 +778,6 @@ main (int   argc,
                                      pool_str2id (pool, "module-default()", 1),
                                      REL_WITHOUT,
                                      1);
-  Id *ndef_modules = pool_whatprovides_ptr (pool, ndef_modules_rel);
 
   g_auto(Queue) pile;
   queue_init (&pile);
@@ -879,7 +878,7 @@ main (int   argc,
 
                   map_setall (pool->considered);
                   /* Disable all non-default unrelated modules */
-                  Id *pp = ndef_modules;
+                  Id *pp = pool_whatprovides_ptr (pool, ndef_modules_rel);
                   for (; *pp; pp++)
                     if (!queue_contains (&t, *pp))
                       map_clr (pool->considered, *pp);


### PR DESCRIPTION
It seems to me like this should not have any effect (except of possibly slightly worse performance), but it looks like with this #25 does not happen anymore (or maybe just a lot less often).