### PR TITLE
Mask bare RPMs

### DIFF
--- a/fus.c
+++ b/fus.c
@@ -872,6 +872,12 @@ resolve_all_solvables (Pool  *pool,
           if (!g_str_has_prefix (pool_id2str (pool, s->name), "module:"))
             {
               g_debug ("Installing %s:", pool_solvid2str (pool, p));
+
+              /* Disable all non-default unrelated modules */
+              Id *pp = pool_whatprovides_ptr (pool, ndef_modules_rel);
+              for (; *pp; pp++)
+                disable_module (pool, *pp);
+
               mask_bare_rpms (pool);
 
               if (!_install_transaction (pool, pile, &job, &tested, 2))


### PR DESCRIPTION
This implements the masking @contyk described in #33 when resolving dependencies for packages in modules. However that is not sufficient to fix the problem. It works in the transaction created for the module, but all RPMs that are found in that transaction are added to the pile, and then tested again separately.

At that step even RPMs from a module are handled as if they were bare, because the modular dependencies are no longer visible.

That's what the second commit is trying to fix. It immediately marks the added packages as tested. 

With both patches, the reproducer from #33 is working correctly. Testing on real data it seems to remove a lot of packages though, so there is probably a reason why it was there in the first place.