### PR TITLE
Bump libmodulemd version to 1.6 and use new API

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ dep_glib = dependency('glib-2.0')
 dep_gio = dependency('gio-2.0')
 dep_libsolv = dependency('libsolv', version : '>= 0.6.34')
 dep_libsolvext = dependency('libsolvext', version : '>= 0.6.34')
-dep_modulemd = dependency('modulemd', version : '>= 1.4')
+dep_modulemd = dependency('modulemd', version : '>= 1.6')
 
 add_project_arguments('-DG_LOG_DOMAIN="fus"', language : 'c')
 exe_main = executable('fus', 'fus.c', 'main.c', dependencies : [dep_glib, dep_gio, dep_libsolv, dep_libsolvext, dep_modulemd], install : true)


### PR DESCRIPTION
ModulemdModule is being deprecated, so use ModulemdModuleStream instead.
This change is also a preparation for when the 2.0 API is ready.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>