### PR TITLE
Make sure GError object is initialized

### DIFF
--- a/fus.c
+++ b/fus.c
@@ -658,7 +658,7 @@ create_repo (Pool         *pool,
   fp = solv_xfopen (fname, "r");
   if (fp != NULL)
     {
-      g_autoptr(GError) e;
+      g_autoptr(GError) e = NULL;
       if (!repo_add_modulemd (repo, fp, NULL, REPO_LOCALPOOL | REPO_EXTEND_SOLVABLES, &e))
         g_warning ("Could not add modules from repo %s: %s", name, e->message);
       fclose (fp);


### PR DESCRIPTION
Otherwise libmodulemd will fail with the message

libmodulemd-CRITICAL **: 18:46:05.119: modulemd_subdocument_info_get_data_parser: assertion 'error == NULL || *error == NULL' failed

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>