### PR TITLE
Allow wildcards in exclude patterns

### DIFF
--- a/fus.c
+++ b/fus.c
@@ -194,7 +194,7 @@ apply_excludes (Pool       *pool,
     {
       g_auto(Queue) sel;
       queue_init (&sel);
-      selection_make (pool, &sel, *exclude, SELECTION_NAME | SELECTION_DOTARCH);
+      selection_make (pool, &sel, *exclude, SELECTION_NAME | SELECTION_GLOB | SELECTION_DOTARCH);
       if (!sel.count)
         {
           g_warning ("Nothing matches exclude '%s'", *exclude);


### PR DESCRIPTION
Instead of having to specify exact package name, allow using globs.