### PR TITLE
Add a failing test case for build in multiple modules

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -282,5 +282,7 @@ int main (int argc, char **argv)
   ADD_SOLV_FAIL_TEST ("/fail/module/broken", "module-broken");
   ADD_SOLV_FAIL_TEST ("/fail/moddep/broken", "moddep-broken");
 
+  ADD_TEST ("/module/multiple", "build-in-more-modules");
+
   return g_test_run ();
 }

--- a/tests/build-in-more-modules/expected
+++ b/tests/build-in-more-modules/expected
@@ -1,0 +1,2 @@
+*foo-1-1.noarch@repo
+module:foo-mod:stable:2020:deadbeef.noarch@yaml

--- a/tests/build-in-more-modules/input
+++ b/tests/build-in-more-modules/input
@@ -1,0 +1,1 @@
+module(foo-mod:stable)

--- a/tests/build-in-more-modules/modules.yaml
+++ b/tests/build-in-more-modules/modules.yaml
@@ -1,0 +1,42 @@
+---
+document: modulemd
+version: 2
+data:
+  name: foo-mod
+  stream: stable
+  version: 2020
+  context: deadbeef
+  arch: noarch
+  summary: Just a module
+  description: Module for testing fus
+  license:
+    module:
+      - Beerware
+  artifacts:
+    rpms:
+      - foo-0:1-1.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: foo-mod
+  stream: stable
+  version: 2019
+  context: cafebabe
+  arch: noarch
+  summary: Just a module
+  description: Module for testing fus
+  license:
+    module:
+      - Beerware
+  artifacts:
+    rpms:
+      - foo-0:1-1.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: foo-mod
+  stream: stable

--- a/tests/build-in-more-modules/packages.repo
+++ b/tests/build-in-more-modules/packages.repo
@@ -1,0 +1,3 @@
+=Ver: 2.0
+
+=Pkg: foo 1 1 noarch


### PR DESCRIPTION
There are two versions of the same module stream in the repo. They both contain the exact same RPM.

Fus reports dependency issues with the modular package.

If the input modulemd only contains the 2020 version, the process finishes fine. If only 2019 is present, the test fails because the older version is pulled in.